### PR TITLE
Refactor debug menu behavior

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppDelegate.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppDelegate.swift
@@ -25,11 +25,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Appearance.shared,
         CrashReportingConfiguration(),
         AnalyticsConfiguration(),
+        DebugMenuConfiguration(),
         ]
 
     // Anything that relies on the existence of a window and an initial viewcontroller should be in this postWindowConfigurations array
     let rootViewControllerDependentConfigurations: [AppLifecycle] = [
-        DebugMenuConfiguration(),
         ]
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
@@ -21,7 +21,7 @@ class DebugMenuConfiguration: AppLifecycle {
 
 }
 
-class DebugMenu {
+fileprivate class DebugMenu {
     static let shared: DebugMenu = DebugMenu()
 
     func enableDebugGesture(_ viewController: UIViewController) {
@@ -32,6 +32,11 @@ class DebugMenu {
     }
 
     @objc func openDebugAlert() {
+        guard let rootViewController = AppDelegate.shared?.window?.rootViewController else {
+            Log.warn("Debug alert unable to present since the window rootViewController is nil")
+            return
+        }
+
         var debug: UIAlertController
 
         if let dictionary = Bundle.main.infoDictionary,
@@ -56,9 +61,9 @@ class DebugMenu {
         debug.addAction(UIAlertAction(title: "Cancel",
                                       style: .cancel, handler: nil))
 
-        var topMostViewController = AppDelegate.shared?.window?.rootViewController
+        var topMostViewController: UIViewController? = rootViewController
         while topMostViewController?.presentedViewController != nil {
-            topMostViewController = topMostViewController?.presentedViewController
+            topMostViewController = topMostViewController?.presentedViewController!
         }
         topMostViewController?.present(debug, animated: true, completion: nil)
     }

--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/DebugMenuConfiguration.swift
@@ -16,18 +16,19 @@ class DebugMenuConfiguration: AppLifecycle {
     }
 
     func onDidLaunch(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
-        // Adds (by default) a 2 finger triple tap gesture to present a debug menu
-        enableDebugGesture()
-
+        DefaultBehaviors(behaviors: [DebugMenuBehavior()]).inject()
     }
 
-    func enableDebugGesture() {
+}
+
+class DebugMenu {
+    static let shared: DebugMenu = DebugMenu()
+
+    func enableDebugGesture(_ viewController: UIViewController) {
         let debugGesture = UITapGestureRecognizer(target: self, action: #selector(openDebugAlert))
         debugGesture.numberOfTapsRequired = 3
         debugGesture.numberOfTouchesRequired = 2
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.window?.addGestureRecognizer(debugGesture)
-        }
+        viewController.view.addGestureRecognizer(debugGesture)
     }
 
     @objc func openDebugAlert() {
@@ -52,9 +53,22 @@ class DebugMenuConfiguration: AppLifecycle {
                 NSLog("Logout: \(String(describing: error))")
             })
         }))
-        debug.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.window?.rootViewController?.present(debug, animated: true, completion: nil)
+        debug.addAction(UIAlertAction(title: "Cancel",
+                                      style: .cancel, handler: nil))
+
+        var topMostViewController = AppDelegate.shared?.window?.rootViewController
+        while topMostViewController?.presentedViewController != nil {
+            topMostViewController = topMostViewController?.presentedViewController
         }
+        topMostViewController?.present(debug, animated: true, completion: nil)
     }
+}
+
+public class DebugMenuBehavior: ViewControllerLifecycleBehavior {
+
+    public init() {}
+    public func afterAppearing(_ viewController: UIViewController, animated: Bool) {
+        DebugMenu.shared.enableDebugGesture(viewController)
+    }
+
 }

--- a/PRODUCTNAME/app/PRODUCTNAMETests/Payloads.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Payloads.swift
@@ -14,7 +14,7 @@ enum Payloads {
         let json = [
             "refreshToken": "FAKE_REFRESH_TOKEN",
             "token": "FAKE_TOKEN",
-            "expirationDate": Formatters.ISODateFormatter.string(from: Date.distantFuture)
+            "expirationDate": Formatters.ISODateFormatter.string(from: Date.distantFuture),
         ]
         do {
             return try JSONSerialization.data(withJSONObject: json)
@@ -27,8 +27,8 @@ enum Payloads {
     static let test: Data = {
         let json = [
             [
-                "value": "FAKE_VALUE"
-            ]
+                "value": "FAKE_VALUE",
+            ],
         ]
         do {
             return try JSONSerialization.data(withJSONObject: json)

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppDelegate.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppDelegate.swift
@@ -25,11 +25,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Appearance.shared,
         CrashReportingConfiguration(),
         AnalyticsConfiguration(),
+        DebugMenuConfiguration(),
         ]
 
     // Anything that relies on the existence of a window and an initial viewcontroller should be in this postWindowConfigurations array
     let rootViewControllerDependentConfigurations: [AppLifecycle] = [
-        DebugMenuConfiguration(),
         ]
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -39,13 +39,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             return true
         }
 
-        let window = UIWindow(frame: UIScreen.main.bounds)
-        self.window = window
-
         for config in preWindowConfigurations where config.isEnabled {
             config.onDidLaunch(application: application, launchOptions: launchOptions)
         }
 
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        self.window = window
         self.coordinator = AppCoordinator(window: window)
         coordinator.start()
 

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/DebugMenuConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/DebugMenuConfiguration.swift
@@ -16,18 +16,19 @@ class DebugMenuConfiguration: AppLifecycle {
     }
 
     func onDidLaunch(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
-        // Adds (by default) a 2 finger triple tap gesture to present a debug menu
-        enableDebugGesture()
-
+        DefaultBehaviors(behaviors: [DebugMenuBehavior()]).inject()
     }
 
-    func enableDebugGesture() {
+}
+
+class DebugMenu {
+    static let shared: DebugMenu = DebugMenu()
+
+    func enableDebugGesture(_ viewController: UIViewController) {
         let debugGesture = UITapGestureRecognizer(target: self, action: #selector(openDebugAlert))
         debugGesture.numberOfTapsRequired = 3
         debugGesture.numberOfTouchesRequired = 2
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.window?.addGestureRecognizer(debugGesture)
-        }
+        viewController.view.addGestureRecognizer(debugGesture)
     }
 
     @objc func openDebugAlert() {
@@ -52,9 +53,22 @@ class DebugMenuConfiguration: AppLifecycle {
                 NSLog("Logout: \(String(describing: error))")
             })
         }))
-        debug.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-            appDelegate.window?.rootViewController?.present(debug, animated: true, completion: nil)
+        debug.addAction(UIAlertAction(title: "Cancel",
+                                      style: .cancel, handler: nil))
+
+        var topMostViewController = AppDelegate.shared?.window?.rootViewController
+        while topMostViewController?.presentedViewController != nil {
+            topMostViewController = topMostViewController?.presentedViewController
         }
+        topMostViewController?.present(debug, animated: true, completion: nil)
     }
+}
+
+public class DebugMenuBehavior: ViewControllerLifecycleBehavior {
+
+    public init() {}
+    public func afterAppearing(_ viewController: UIViewController, animated: Bool) {
+        DebugMenu.shared.enableDebugGesture(viewController)
+    }
+
 }

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Payloads.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Payloads.swift
@@ -14,7 +14,7 @@ enum Payloads {
         let json = [
             "refreshToken": "FAKE_REFRESH_TOKEN",
             "token": "FAKE_TOKEN",
-            "expirationDate": Formatters.ISODateFormatter.string(from: Date.distantFuture)
+            "expirationDate": Formatters.ISODateFormatter.string(from: Date.distantFuture),
         ]
         do {
             return try JSONSerialization.data(withJSONObject: json)
@@ -27,8 +27,8 @@ enum Payloads {
     static let test: Data = {
         let json = [
             [
-                "value": "FAKE_VALUE"
-            ]
+                "value": "FAKE_VALUE",
+            ],
         ]
         do {
             return try JSONSerialization.data(withJSONObject: json)


### PR DESCRIPTION
Refactored debug menu to inject the debug gesture into UIViewControllers. Uses topMostViewController search from rootViewController to avoid adding an extension to openDebugAlert on ALL UIViewControllers that would have to be macro’d out in prod builds. Also avoids the alternative of having a debug menu instance for each view controller.

To test swap out UIViewController() with FirstTabViewController() or any UIViewController subclass since the behavior injection work ignores apple bundle classes like UIViewController etc.  

After switching the class you can 2 finger triple tap to see the debug menu again.

Also note the debug menu no longer has to wait for the UIWindow to be created, in fact if it happens there it's too late for the initial view controller to get the behavior due to injection and swizzling. I think there is still value in a post window configuration loop but for now it's an empty array and a no-op to show devs where post window dependent configuration could live.