### PR TITLE
Add DS_Store to PRODUCTNAME gitignore

### DIFF
--- a/PRODUCTNAME/.gitignore
+++ b/PRODUCTNAME/.gitignore
@@ -20,6 +20,7 @@ xcuserdata/
 ## Other
 *.moved-aside
 *.xcuserstate
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/.gitignore
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/.gitignore
@@ -20,6 +20,7 @@ xcuserdata/
 ## Other
 *.moved-aside
 *.xcuserstate
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
Fixes #19 - we already had `DS_Store` included in the `.gitignore` at the root directory of the project, but not inside `PRODUCTNAME`’s `.gitignore`.