### PR TITLE
UnmarshalingWithContext support

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAME/API/APIClient.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/API/APIClient.swift
@@ -26,14 +26,100 @@ final class APIClient {
         manager.retrier = oauthClient
     }
 
+// MARK: - JSON
+
+    /**
+     *For ResponseType: JSONObject*
+
+     Perform request and execute completion block leveraging a `JSONObject`. Use this when an API response doesn't map directly to your object graph.
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` of `JSONObject`
+        - completion: A closure to process the API response
+        - responseObject: the response JSON as a `JSONObject`
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
+    func requestJSON<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ responseObject: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType == JSONObject {
+        return manager.requestJSON(baseURL, endpoint: endpoint, completion: completion)
+    }
+
+// MARK: - Unmarshaling
+
+    /**
+     *For ResponseType: Unmarshaling*
+
+     Perform request and serialize the response automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
         return manager.request(baseURL, endpoint: endpoint, completion: completion)
     }
 
+    /**
+     *For ResponseType: [Unmarshaling]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
         return manager.request(baseURL, endpoint: endpoint, completion: completion)
+    }
+
+// MARK: - UnmarshalingWithContext
+
+    /**
+     *For ResponseType: UnmarshalingWithContext*
+
+     Perform request and serialize the response automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `UnmarshalingWithContext`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, context: Endpoint.ResponseType.ContextType, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: UnmarshalingWithContext {
+        return manager.request(baseURL, endpoint: endpoint, context: context, completion: completion)
+    }
+
+    /**
+     *For ResponseType: [UnmarshalingWithContext]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, context: Endpoint.ResponseType.Iterator.Element.ContextType, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: UnmarshalingWithContext {
+        return manager.request(baseURL, endpoint: endpoint, context: context, completion: completion)
     }
 
 }

--- a/PRODUCTNAME/app/PRODUCTNAME/API/APISerialization.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/API/APISerialization.swift
@@ -9,9 +9,9 @@
 import Alamofire
 import Marshal
 
-// Response serializer to import JSON Object using Marshal and return an object
+/// Response serializer to import JSON Object using Marshal and return an object
 func APIObjectResponseSerializer<T: Unmarshaling>(type: T.Type) -> DataResponseSerializer<T> {
-    return DataResponseSerializer() { _, _, data, error in
+    return DataResponseSerializer { _, _, data, error in
         do {
             if let error = error { throw error }
 
@@ -31,9 +31,9 @@ func APIObjectResponseSerializer<T: Unmarshaling>(type: T.Type) -> DataResponseS
     }
 }
 
-// Response serializer to import JSON Array using Marshal and return an array of objects
+/// Response serializer to import JSON Array using Marshal and return an array of objects
 func APICollectionResponseSerializer<T: Collection>(type: T.Type) -> DataResponseSerializer<T> where T.Iterator.Element: Unmarshaling {
-    return DataResponseSerializer() { _, _, data, error in
+    return DataResponseSerializer { _, _, data, error in
         do {
             if let error = error { throw error }
 
@@ -45,6 +45,59 @@ func APICollectionResponseSerializer<T: Collection>(type: T.Type) -> DataRespons
                 throw APIError.invalidResponse
             }
             let result = try collection.map({ try T.Iterator.Element.init(object: $0) })
+            guard let typedResult = result as? T else {
+                // Result is identical to T, but of type [T.Iterator.Element] which Swift can not infer correctly.
+                fatalError("Unable to transfer typed arrays")
+            }
+            return .success(typedResult)
+        }
+        catch {
+            return .failure(error as NSError)
+        }
+    }
+}
+
+/// Response serializer to import JSON Object using Marshal and return a managed object
+func APIObjectResponseSerializer<T: UnmarshalingWithContext>(type: T.Type, context: T.ContextType) -> DataResponseSerializer<T> {
+    return DataResponseSerializer { _, _, data, error in
+        do {
+            if let error = error { throw error }
+
+            guard let validData = data, validData.count > 0 else {
+                throw APIError.invalidResponse
+            }
+            let JSON = try JSONSerialization.jsonObject(with: validData, options: [])
+            guard let object = JSON as? JSONObject else {
+                throw APIError.invalidResponse
+            }
+
+            let result = try type.value(from: object, inContext: context)
+            guard let typedResult = result as? T else {
+                // Result is identical to T, but of type T.ConvertibleType which Swift can not infer correctly.
+                fatalError("")
+            }
+            return Result.success(typedResult)
+        }
+        catch {
+            return .failure(error as NSError)
+        }
+    }
+}
+
+/// Response serializer to import JSON Array using Marshal and return an array of managed objects
+func APICollectionResponseSerializer<T: Collection>(type: T.Type, context: T.Iterator.Element.ContextType) -> DataResponseSerializer<T> where T.Iterator.Element: UnmarshalingWithContext {
+    return DataResponseSerializer { _, _, data, error in
+        do {
+            if let error = error { throw error }
+
+            guard let validData = data, validData.count > 0 else {
+                throw APIError.invalidResponse
+            }
+            let JSON = try JSONSerialization.jsonObject(with: validData, options: [])
+            guard let collection = JSON as? [JSONObject] else {
+                throw APIError.invalidResponse
+            }
+            let result = try collection.map({ try T.Iterator.Element.value(from: $0, inContext: context)})
             guard let typedResult = result as? T else {
                 // Result is identical to T, but of type [T.Iterator.Element] which Swift can not infer correctly.
                 fatalError("Unable to transfer typed arrays")

--- a/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
@@ -33,11 +33,11 @@ extension SessionManager {
      Perform request and execute completion block leveraging a `JSONObject`. Use this when an API response doesn't map directly to your object graph.
 
      - Parameters:
-     - baseURL: The base url to apply the endpoint `path` to
-     - endpoint: An `APIEndpoint` with an associated `ResponseType` of `JSONObject`
-     - completion: A closure to process the API response
-     - responseObject: the response JSON as a `JSONObject`
-     - error: a server or serialization error
+        - baseURL: The base url to apply the endpoint `path` to
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` of `JSONObject`
+        - completion: A closure to process the API response
+        - responseObject: the response JSON as a `JSONObject`
+        - error: a server or serialization error
 
      - Returns: a `DataRequest`
      */
@@ -59,11 +59,11 @@ extension SessionManager {
      Perform request and serialize the response automatically according to your Response Type's `Unmarshaling` conformance
 
      - Parameters:
-     - baseURL: The base url to apply the endpoint `path` to
-     - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `Unmarshaling`
-     - completion: A closure to process the API response
-     - object: the unmarhsaled response object
-     - error: a server or serialization error
+        - baseURL: The base url to apply the endpoint `path` to
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
 
      - Returns: a `DataRequest`
      */
@@ -84,11 +84,11 @@ extension SessionManager {
      Perform request and serialize the returned collection automatically according to your Response Type's `Unmarshaling` conformance
 
      - Parameters:
-     - baseURL: The base url to apply the endpoint `path` to
-     - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
-     - completion: A closure to process the API response
-     - objects: the unmarhsaled response collection
-     - error: a server or serialization error
+        - baseURL: The base url to apply the endpoint `path` to
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
 
      - Returns: a `DataRequest`
      */
@@ -111,11 +111,11 @@ extension SessionManager {
      Perform request and serialize the response automatically according to your Response Type's `UnmarshalingWithContext` conformance
 
      - Parameters:
-     - baseURL: The base url to apply the endpoint `path` to
-     - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `UnmarshalingWithContext`
-     - completion: A closure to process the API response
-     - object: the unmarhsaled response object
-     - error: a server or serialization error
+        - baseURL: The base url to apply the endpoint `path` to
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `UnmarshalingWithContext`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
 
      - Returns: a `DataRequest`
      */
@@ -136,11 +136,11 @@ extension SessionManager {
      Perform request and serialize the returned collection automatically according to your Response Type's `UnmarshalingWithContext` conformance
 
      - Parameters:
-     - baseURL: The base url to apply the endpoint `path` to
-     - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
-     - completion: A closure to process the API response
-     - objects: the unmarhsaled response collection
-     - error: a server or serialization error
+        - baseURL: The base url to apply the endpoint `path` to
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
 
      - Returns: a `DataRequest`
      */

--- a/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
@@ -25,8 +25,50 @@ extension SessionManager {
         return request
     }
 
+    // Mark - JSON
+
+    /**
+     *For ResponseType: JSONObject*
+
+     Perform request and execute completion block leveraging a `JSONObject`. Use this when an API response doesn't map directly to your object graph.
+
+     - Parameters:
+     - baseURL: The base url to apply the endpoint `path` to
+     - endpoint: An `APIEndpoint` with an associated `ResponseType` of `JSONObject`
+     - completion: A closure to process the API response
+     - responseObject: the response JSON as a `JSONObject`
+     - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
+    func requestJSON<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, completion: @escaping (_ responseObject: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest {
+        let request = self.request(baseURL, endpoint: endpoint)
+        request.validate(APIResponseValidator)
+        request.responseJSON { response in
+            completion(response.result.value as? Endpoint.ResponseType, response.error)
+        }
+        return request
+    }
+
+    // Mark - Unmarshaling
+
+    /**
+     *For ResponseType: Unmarshaling*
+
+     Perform request and serialize the response automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+     - baseURL: The base url to apply the endpoint `path` to
+     - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `Unmarshaling`
+     - completion: A closure to process the API response
+     - object: the unmarhsaled response object
+     - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
         let request = self.request(baseURL, endpoint: endpoint)
         let handler = APIObjectResponseSerializer(type: Endpoint.ResponseType.self)
         request.validate(APIResponseValidator)
@@ -36,8 +78,22 @@ extension SessionManager {
         return request
     }
 
+    /**
+     *For ResponseType: [Unmarshaling]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+     - baseURL: The base url to apply the endpoint `path` to
+     - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+     - completion: A closure to process the API response
+     - objects: the unmarhsaled response collection
+     - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
+    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
         let request = self.request(baseURL, endpoint: endpoint)
         let handler = APICollectionResponseSerializer(type: Endpoint.ResponseType.self)
         request.validate(APIResponseValidator)
@@ -46,4 +102,57 @@ extension SessionManager {
         }
         return request
     }
+
+    // Mark - UnmarshalingWithContext
+
+    /**
+     *For ResponseType: UnmarshalingWithContext*
+
+     Perform request and serialize the response automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+     - baseURL: The base url to apply the endpoint `path` to
+     - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `UnmarshalingWithContext`
+     - completion: A closure to process the API response
+     - object: the unmarhsaled response object
+     - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, context: Endpoint.ResponseType.ContextType, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: UnmarshalingWithContext {
+        let request = self.request(baseURL, endpoint: endpoint)
+        let handler = APIObjectResponseSerializer(type: Endpoint.ResponseType.self, context: context)
+        request.validate(APIResponseValidator)
+        request.response(responseSerializer: handler) { response in
+            completion(response.result.value, response.result.error)
+        }
+        return request
+    }
+
+    /**
+     *For ResponseType: [UnmarshalingWithContext]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+     - baseURL: The base url to apply the endpoint `path` to
+     - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+     - completion: A closure to process the API response
+     - objects: the unmarhsaled response collection
+     - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ baseURL: URL, endpoint: Endpoint, context: Endpoint.ResponseType.Iterator.Element.ContextType, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: UnmarshalingWithContext {
+        let request = self.request(baseURL, endpoint: endpoint)
+        let handler = APICollectionResponseSerializer(type: Endpoint.ResponseType.self, context: context)
+        request.validate(APIResponseValidator)
+        request.response(responseSerializer: handler) { response in
+            completion(response.result.value, response.result.error)
+        }
+        return request
+    }
+
 }

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/APIClient.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/APIClient.swift
@@ -26,14 +26,100 @@ final class APIClient {
         manager.retrier = oauthClient
     }
 
+// MARK: - JSON
+
+    /**
+     *For ResponseType: JSONObject*
+
+     Perform request and execute completion block leveraging a `JSONObject`. Use this when an API response doesn't map directly to your object graph.
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` of `JSONObject`
+        - completion: A closure to process the API response
+        - responseObject: the response JSON as a `JSONObject`
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
+    func requestJSON<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ responseObject: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType == JSONObject {
+        return manager.requestJSON(baseURL, endpoint: endpoint, completion: completion)
+    }
+
+// MARK: - Unmarshaling
+
+    /**
+     *For ResponseType: Unmarshaling*
+
+     Perform request and serialize the response automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Unmarshaling {
         return manager.request(baseURL, endpoint: endpoint, completion: completion)
     }
 
+    /**
+     *For ResponseType: [Unmarshaling]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `Unmarshaling` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
     @discardableResult
-    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (Endpoint.ResponseType?, Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: Unmarshaling {
         return manager.request(baseURL, endpoint: endpoint, completion: completion)
+    }
+
+// MARK: - UnmarshalingWithContext
+
+    /**
+     *For ResponseType: UnmarshalingWithContext*
+
+     Perform request and serialize the response automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` conforming to `UnmarshalingWithContext`
+        - completion: A closure to process the API response
+        - object: the unmarhsaled response object
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, context: Endpoint.ResponseType.ContextType, completion: @escaping (_ object: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: UnmarshalingWithContext {
+        return manager.request(baseURL, endpoint: endpoint, context: context, completion: completion)
+    }
+
+    /**
+     *For ResponseType: [UnmarshalingWithContext]*
+
+     Perform request and serialize the returned collection automatically according to your Response Type's `UnmarshalingWithContext` conformance
+
+     - Parameters:
+        - endpoint: An `APIEndpoint` with an associated `ResponseType` which is a collection of bojects conforming to `Unmarshaling`
+        - completion: A closure to process the API response
+        - objects: the unmarhsaled response collection
+        - error: a server or serialization error
+
+     - Returns: a `DataRequest`
+     */
+    @discardableResult
+    func request<Endpoint: APIEndpoint>(_ endpoint: Endpoint, context: Endpoint.ResponseType.Iterator.Element.ContextType, completion: @escaping (_ objects: Endpoint.ResponseType?, _ error: Error?) -> Void) -> DataRequest where Endpoint.ResponseType: Collection, Endpoint.ResponseType.Iterator.Element: UnmarshalingWithContext {
+        return manager.request(baseURL, endpoint: endpoint, context: context, completion: completion)
     }
 
 }

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/APISerialization.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/APISerialization.swift
@@ -9,9 +9,9 @@
 import Alamofire
 import Marshal
 
-// Response serializer to import JSON Object using Marshal and return an object
+/// Response serializer to import JSON Object using Marshal and return an object
 func APIObjectResponseSerializer<T: Unmarshaling>(type: T.Type) -> DataResponseSerializer<T> {
-    return DataResponseSerializer() { _, _, data, error in
+    return DataResponseSerializer { _, _, data, error in
         do {
             if let error = error { throw error }
 
@@ -31,9 +31,9 @@ func APIObjectResponseSerializer<T: Unmarshaling>(type: T.Type) -> DataResponseS
     }
 }
 
-// Response serializer to import JSON Array using Marshal and return an array of objects
+/// Response serializer to import JSON Array using Marshal and return an array of objects
 func APICollectionResponseSerializer<T: Collection>(type: T.Type) -> DataResponseSerializer<T> where T.Iterator.Element: Unmarshaling {
-    return DataResponseSerializer() { _, _, data, error in
+    return DataResponseSerializer { _, _, data, error in
         do {
             if let error = error { throw error }
 
@@ -45,6 +45,59 @@ func APICollectionResponseSerializer<T: Collection>(type: T.Type) -> DataRespons
                 throw APIError.invalidResponse
             }
             let result = try collection.map({ try T.Iterator.Element.init(object: $0) })
+            guard let typedResult = result as? T else {
+                // Result is identical to T, but of type [T.Iterator.Element] which Swift can not infer correctly.
+                fatalError("Unable to transfer typed arrays")
+            }
+            return .success(typedResult)
+        }
+        catch {
+            return .failure(error as NSError)
+        }
+    }
+}
+
+/// Response serializer to import JSON Object using Marshal and return a managed object
+func APIObjectResponseSerializer<T: UnmarshalingWithContext>(type: T.Type, context: T.ContextType) -> DataResponseSerializer<T> {
+    return DataResponseSerializer { _, _, data, error in
+        do {
+            if let error = error { throw error }
+
+            guard let validData = data, validData.count > 0 else {
+                throw APIError.invalidResponse
+            }
+            let JSON = try JSONSerialization.jsonObject(with: validData, options: [])
+            guard let object = JSON as? JSONObject else {
+                throw APIError.invalidResponse
+            }
+
+            let result = try type.value(from: object, inContext: context)
+            guard let typedResult = result as? T else {
+                // Result is identical to T, but of type T.ConvertibleType which Swift can not infer correctly.
+                fatalError("")
+            }
+            return Result.success(typedResult)
+        }
+        catch {
+            return .failure(error as NSError)
+        }
+    }
+}
+
+/// Response serializer to import JSON Array using Marshal and return an array of managed objects
+func APICollectionResponseSerializer<T: Collection>(type: T.Type, context: T.Iterator.Element.ContextType) -> DataResponseSerializer<T> where T.Iterator.Element: UnmarshalingWithContext {
+    return DataResponseSerializer { _, _, data, error in
+        do {
+            if let error = error { throw error }
+
+            guard let validData = data, validData.count > 0 else {
+                throw APIError.invalidResponse
+            }
+            let JSON = try JSONSerialization.jsonObject(with: validData, options: [])
+            guard let collection = JSON as? [JSONObject] else {
+                throw APIError.invalidResponse
+            }
+            let result = try collection.map({ try T.Iterator.Element.value(from: $0, inContext: context)})
             guard let typedResult = result as? T else {
                 // Result is identical to T, but of type [T.Iterator.Element] which Swift can not infer correctly.
                 fatalError("Unable to transfer typed arrays")


### PR DESCRIPTION
Adds support for serializing to `UnmarshalingWithContext` conforming objects or arrays to allow for supporting ManagedObjects. Also adds serialization just to Marshal's `JSONObject` type. Brings our serialization support to date to:
- just a plain `JSONObject`
- in-memory objects (`Unmarshaling`) and arrays
- persisted objects (`UnmarshalingWithContext`) and arrays