### PR TITLE
Use bundle default path

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -3,7 +3,7 @@
 set -e
 
 git init
-bundle install --path=./
+bundle install
 cd app
 bundle exec pod install
 if [[ "{{ cookiecutter.hockey_key }}" =~ .*[nN][oO].* ]]


### PR DESCRIPTION
There doesn't seem to be any issue with using the default bundle install path, so we don't need the gems directory in the project.