### PR TITLE
Update scheme naming and configuration

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAME.xcodeproj/xcshareddata/xcschemes/PRODUCTNAME.xcscheme
+++ b/PRODUCTNAME/app/PRODUCTNAME.xcodeproj/xcshareddata/xcschemes/PRODUCTNAME.xcscheme
@@ -23,11 +23,21 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Sprint"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ABC778881DC90B7A00815FB9"
+               BuildableName = "PRODUCTNAMETests.xctest"
+               BlueprintName = "PRODUCTNAMETests"
+               ReferencedContainer = "container:PRODUCTNAME.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -42,7 +52,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Sprint"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -65,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Sprint"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -82,10 +92,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Sprint">
+      buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Sprint"
+      buildConfiguration = "Develop"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/PRODUCTNAME/app/PRODUCTNAME.xcodeproj/xcshareddata/xcschemes/develop-PRODUCTNAME.xcscheme
+++ b/PRODUCTNAME/app/PRODUCTNAME.xcodeproj/xcshareddata/xcschemes/develop-PRODUCTNAME.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Develop"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -75,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Develop"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -92,10 +92,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Develop">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Develop"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/PRODUCTNAME/app/fastlane/Fastfile
+++ b/PRODUCTNAME/app/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
 
   desc "Builds and submits a Develop release to Hockey"
   lane :develop do
-    build("PRODUCTNAME", 'enterprise')
+    build("develop-PRODUCTNAME", 'enterprise')
     hockey(public_identifier: 'ZZHOCKEY_DEVELOP_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_DEVELOPZZ')
     slack(message: "Successfully uploaded build #{build_number} to develop", success: true)
@@ -49,7 +49,7 @@ platform :ios do
 
   desc "Builds and submits a Sprint release to Hockey"
   lane :sprint do
-    build("PRODUCTNAME", 'enterprise')
+    build("sprint-PRODUCTNAME", 'enterprise')
     hockey(public_identifier: 'ZZHOCKEY_SPRINT_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_SPRINTZZ')
     slack(message: "Successfully uploaded build #{build_number} to sprint", success: true)

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
@@ -41,7 +41,7 @@ platform :ios do
 
   desc "Builds and submits a Develop release to Hockey"
   lane :develop do
-    build("{{ cookiecutter.project_name | replace(' ', '') }}", 'enterprise')
+    build("develop-{{ cookiecutter.project_name | replace(' ', '') }}", 'enterprise')
     hockey(public_identifier: 'ZZHOCKEY_DEVELOP_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_DEVELOPZZ')
     slack(message: "Successfully uploaded build #{build_number} to develop", success: true)
@@ -49,7 +49,7 @@ platform :ios do
 
   desc "Builds and submits a Sprint release to Hockey"
   lane :sprint do
-    build("{{ cookiecutter.project_name | replace(' ', '') }}", 'enterprise')
+    build("sprint-{{ cookiecutter.project_name | replace(' ', '') }}", 'enterprise')
     hockey(public_identifier: 'ZZHOCKEY_SPRINT_IDZZ')
     # upload_symbols_to_crashlytics(:api_token => 'ZZCRASHLYTICS_API_TOKEN_SPRINTZZ')
     slack(message: "Successfully uploaded build #{build_number} to sprint", success: true)

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/develop-{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/develop-{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Develop"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -75,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Develop"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -92,10 +92,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Develop">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Develop"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/sprint-{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/sprint-{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
@@ -23,21 +23,11 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Sprint"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ABC778881DC90B7A00815FB9"
-               BuildableName = "{{ cookiecutter.project_name | replace(' ', '') }}Tests.xctest"
-               BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}Tests"
-               ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -53,18 +43,16 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Sprint"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <PathRunnable
+      <BuildableProductRunnable
          runnableDebuggingMode = "0">
-      </PathRunnable>
-      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "ABC778741DC90B7A00815FB9"
@@ -72,12 +60,12 @@
             BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}"
             ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Sprint"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -94,10 +82,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "Sprint">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Sprint"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj/xcshareddata/xcschemes/{{ cookiecutter.project_name | replace(' ', '') }}.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "ABC778741DC90B7A00815FB9"
-               BuildableName = "{{ cookiecutter.project_name | replace(' ', '') }}.app"
+               BuildableName = "develop-{{ cookiecutter.project_name | replace(' ', '') }}.app"
                BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}"
                ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "ABC778741DC90B7A00815FB9"
-            BuildableName = "{{ cookiecutter.project_name | replace(' ', '') }}.app"
+            BuildableName = "develop-{{ cookiecutter.project_name | replace(' ', '') }}.app"
             BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}"
             ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "ABC778741DC90B7A00815FB9"
-            BuildableName = "{{ cookiecutter.project_name | replace(' ', '') }}.app"
+            BuildableName = "develop-{{ cookiecutter.project_name | replace(' ', '') }}.app"
             BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}"
             ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
          </BuildableReference>
@@ -75,7 +75,7 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -85,7 +85,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "ABC778741DC90B7A00815FB9"
-            BuildableName = "{{ cookiecutter.project_name | replace(' ', '') }}.app"
+            BuildableName = "develop-{{ cookiecutter.project_name | replace(' ', '') }}.app"
             BlueprintName = "{{ cookiecutter.project_name | replace(' ', '') }}"
             ReferencedContainer = "container:{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj">
          </BuildableReference>
@@ -95,7 +95,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Develop"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
The scheme configurations weren't correct, and `sprint` was actually crashing. This updates what is built per scheme to match the name, and has fastlane point to the correct scheme.