### PR TITLE
Fix Request Validation Race Condition

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/API/Alamofire+PRODUCTNAME.swift
@@ -22,7 +22,9 @@ extension SessionManager {
             encoding: endpoint.encoding,
             headers: endpoint.headers
         )
-        endpoint.log(request)
+        DispatchQueue.global().async {
+            endpoint.log(request)
+        }
         return request
     }
 

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/Alamofire+{{ cookiecutter.project_name | replace(' ', '') }}.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/API/Alamofire+{{ cookiecutter.project_name | replace(' ', '') }}.swift
@@ -22,7 +22,9 @@ extension SessionManager {
             encoding: endpoint.encoding,
             headers: endpoint.headers
         )
-        endpoint.log(request)
+        DispatchQueue.global().async {
+            endpoint.log(request)
+        }
         return request
     }
 


### PR DESCRIPTION
Longgggg story short:

The response validations run [here](https://github.com/Raizlabs/ios-template/blob/master/PRODUCTNAME/app/Pods/Alamofire/Source/SessionDelegate.swift#L460)
could be run before the validations were set if the logger acted synchronously. (Since the stubbed response returns immediately)