### PR TITLE
Specify URL correctly.

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestClient.swift
+++ b/PRODUCTNAME/app/PRODUCTNAMETests/Helpers/TestClient.swift
@@ -12,7 +12,7 @@ import Foundation
 enum TestClient {
 
     static var baseURL: URL {
-        return URL(string: "www.google.com/")!
+        return URL(string: "https://google.com")!
     }
 
 }

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestClient.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}Tests/Helpers/TestClient.swift
@@ -12,7 +12,7 @@ import Foundation
 enum TestClient {
 
     static var baseURL: URL {
-        return URL(string: "www.google.com/")!
+        return URL(string: "https://google.com")!
     }
 
 }


### PR DESCRIPTION
If you don't do it this way, the Swift.URL isn't constructed correctly, and OHHTTPStubs gets confused.