### PR TITLE
Slack Screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/PRODUCTNAME/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
@@ -13,19 +16,18 @@ jobs:
       # Setup Ruby dependencies
       - restore_cache:
           keys: 
-            - 1-danger-gems-{{ checksum "Gemfile.lock" }}
+            - 7-gems-{{ checksum "Gemfile.lock" }}
             # Fall back to a previous cache if exact match cannot be found
-            - 1-danger-gems-
+            - 7-gems-
       - run:
           name: Restore Ruby Gems
           command: |
-            bundle check --gemfile Gemfile || bundle install --gemfile Gemfile
+            bundle check || bundle install
       # Cache Gems
       - save_cache:
-          key: 1-danger-gems-{{ checksum "Gemfile.lock" }}
-          # The path to the gems may change if .ruby-version file is changed or CircleCI image is updated.
+          key: 7-gems-{{ checksum "Gemfile.lock" }}
           paths:
-            - "/Users/distiller/.gem/ruby/2.4.4"
+            - "/Users/distiller/project/PRODUCTNAME/app/build/gems"
       - run:
           name: Tests
           command: |
@@ -79,6 +81,9 @@ jobs:
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/PRODUCTNAME/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
@@ -86,9 +91,9 @@ jobs:
       # Setup Ruby dependencies
       - restore_cache:
           keys: 
-            - 6-gems-{{ checksum "Gemfile.lock" }}
+            - 7-gems-{{ checksum "Gemfile.lock" }}
             # Fall back to a previous cache if exact match cannot be found
-            - 6-gems-
+            - 7-gems-
       - run:
           name: Restore Ruby Gems
           command: |
@@ -136,10 +141,9 @@ jobs:
           command: test `git status -s \{\{\ cookiecutter.project_name\ \|\ replace\(\'\ \'\,\ \'\'\)\ \}\}/ | wc -l` -eq 0
       # Cache Gems
       - save_cache:
-          key: 6-gems-{{ checksum "Gemfile.lock" }}
-          # The path to the gems may change if .ruby-version file is changed or CircleCI image is updated.
+          key: 7-gems-{{ checksum "Gemfile.lock" }}
           paths:
-            - "/Users/distiller/.gem/ruby/2.4.4"
+            - "/Users/distiller/project/PRODUCTNAME/app/build/gems"
       # Cache Pods
       - save_cache:
           key: 3-pods-{{ checksum "./PRODUCTNAME/app/Podfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - restore_cache:
           keys: 
             - 1-danger-gems-{{ checksum "Gemfile.lock" }}
+            # Fall back to a previous cache if exact match cannot be found
             - 1-danger-gems-
       - run:
           name: Restore Ruby Gems
@@ -36,12 +37,6 @@ jobs:
           command: |
             cd PRODUCTNAME/app
             bundle exec fastlane coverage
-      - run:
-          name: Screenshots
-          when: always
-          command: |
-            cd PRODUCTNAME/app
-            bundle exec fastlane snapshot
       # Store xcov Code Coverage HTML report artifact 
       - store_artifacts:
           path: /Users/distiller/project/PRODUCTNAME/app/build/xcov
@@ -50,15 +45,28 @@ jobs:
           path: /Users/distiller/project/PRODUCTNAME/app/build/slather
           destination: slather
       - store_artifacts:
-          path: /Users/distiller/project/PRODUCTNAME/app/fastlane/screenshots
-          destination: screenshots
-      - store_artifacts:
           path: /Users/distiller/project/PRODUCTNAME/app/build/scan
           destination: scan
+      # Update Danger as soon as we have code coverage/tests, while waiting for screenshots to be generated
+      - run:
+          name: Danger
+          when: always
+          command: |
+            bundle exec danger --dangerfile=PRODUCTNAME/Dangerfile
       - run:
           name: Upload to Codecov
           when: always
           command: bash <(curl -s https://codecov.io/bash) -f PRODUCTNAME/app/build/slather/cobertura.xml -X coveragepy -X gcov -X xcode
+      - run:
+          name: Screenshots
+          when: always
+          command: |
+            cd PRODUCTNAME/app
+            bundle exec fastlane snapshot
+      - store_artifacts:
+          path: /Users/distiller/project/PRODUCTNAME/app/fastlane/screenshots
+          destination: screenshots
+      # Run Danger again once screenshots are complete
       - run:
           name: Danger
           when: always
@@ -79,6 +87,7 @@ jobs:
       - restore_cache:
           keys: 
             - 6-gems-{{ checksum "Gemfile.lock" }}
+            # Fall back to a previous cache if exact match cannot be found
             - 6-gems-
       - run:
           name: Restore Ruby Gems

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ jobs:
           when: always
           command: |
             bundle exec danger --dangerfile=PRODUCTNAME/Dangerfile
+      - run:
+          name: Post Screenshots to Slack
+          when: always
+          command: |
+            cd PRODUCTNAME/app
+            bundle exec fastlane slackshots
 
   test-xcode-9-3:
     macos:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/Raizlabs/circleci_artifact.git
-  revision: bbbf364f084774d77ad37feb21254bbce6befc68
-  branch: master
-  specs:
-    circleci_artifact (0.1.0)
-      circleci (~> 2.0)
-
-GIT
   remote: https://github.com/Raizlabs/xcov.git
   revision: 41e7d39f97a1665b3048d9035547b025caf9ff91
   branch: 1.4.0-rz
@@ -38,6 +30,8 @@ GEM
     atomos (0.1.2)
     babosa (1.0.2)
     circleci (2.0.2)
+    circleci_artifact (0.1.0)
+      circleci (~> 2.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
       cork
@@ -109,13 +103,13 @@ GEM
       xcov (>= 1.1.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.2)
     emoji_regex (0.1.1)
     escape (0.0.4)
     excon (0.62.0)
-    faraday (0.14.0)
+    faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -265,7 +259,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.2)
     word_wrap (1.0.0)
     xcodeproj (1.5.7)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -282,7 +276,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  circleci_artifact!
+  circleci_artifact
   cocoapods
   danger
   danger-junit

--- a/PRODUCTNAME/.circleci/config.yml
+++ b/PRODUCTNAME/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
       # required to set the correct ruby version
       # see https://circleci.com/docs/2.0/testing-ios/#custom-ruby-versions
     shell: /bin/bash --login -eo pipefail
@@ -15,18 +18,17 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
           # Fall back to a previous cache if exact match cannot be found
-          key: 3-gems-
+          key: 4-gems-
       - run:
           name: Restore Gems
           command: |
-           bundle check --gemfile Gemfile || bundle install --gemfile Gemfile
+           bundle check || bundle install
       - save_cache:
-          key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
-          # The path to the gems may change if .ruby-version file is changed or CircleCI image is updated.
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
           paths:
-            - "/Users/distiller/.gem/ruby/2.4.4"
+            - "/Users/distiller/project/app/build/gems"
       # Make sure that the output directory exists
       - run: mkdir $FL_OUTPUT_DIR
       - run:
@@ -83,11 +85,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane develop
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"
@@ -98,11 +114,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane sprint
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"
@@ -113,11 +143,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane beta
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"

--- a/PRODUCTNAME/.circleci/config.yml
+++ b/PRODUCTNAME/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
       - checkout
       - restore_cache:
           key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 3-gems-
       - run:
           name: Restore Gems
           command: |
@@ -38,12 +40,6 @@ jobs:
           command: |
             cd app
             bundle exec fastlane coverage
-      - run:
-          name: Screenshots
-          when: always
-          command: |
-            cd app
-            bundle exec fastlane snapshot
       # Store xcov and slather Code Coverage HTML report artifacts
       - store_artifacts:
           path: /Users/distiller/project/app/build/xcov
@@ -52,15 +48,28 @@ jobs:
           path: /Users/distiller/project/app/build/slather
           destination: slather
       - store_artifacts:
-          path: /Users/distiller/project/app/fastlane/screenshots
-          destination: screenshots
-      - store_artifacts:
           path: /Users/distiller/project/app/build/scan
           destination: scan
+      # Update Danger as soon as we have code coverage/tests, while waiting for screenshots to be generated
+      - run:
+          name: Danger
+          when: always
+          command: |
+            bundle exec danger
       - run:
           name: Upload to Codecov
           when: always
           command: bash <(curl -s https://codecov.io/bash) -f app/build/slather/cobertura.xml -X coveragepy -X gcov -X xcode      
+      - run:
+          name: Screenshots
+          when: always
+          command: |
+            cd app
+            bundle exec fastlane snapshot
+      - store_artifacts:
+          path: /Users/distiller/project/app/fastlane/screenshots
+          destination: screenshots
+      # Run Danger again once screenshots are complete
       - run:
           name: Danger
           when: always

--- a/PRODUCTNAME/.circleci/config.yml
+++ b/PRODUCTNAME/.circleci/config.yml
@@ -77,6 +77,12 @@ jobs:
           when: always
           command: |
             bundle exec danger
+      - run:
+          name: Post Screenshots to Slack
+          when: always
+          command: |
+            cd app
+            bundle exec fastlane slackshots
             
   integration:
     macos:

--- a/PRODUCTNAME/Dangerfile
+++ b/PRODUCTNAME/Dangerfile
@@ -64,19 +64,23 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
   tests_url = results.url_for_query(tests)
 
   if !tests_url.nil?
-      message "[Test Results](#{tests_url})"
+    message "[Test Results](#{tests_url})"
+  else
+    message "Tests in progress..."
   end
 
   if !xcov_url.nil?
-      message "[Code Coverage: xcov](#{xcov_url})"
+    message "[Code Coverage: xcov](#{xcov_url})"
   end
 
   if !slather_url.nil?
-      message "[Code Coverage: Slather](#{slather_url})"
+    message "[Code Coverage: Slather](#{slather_url})"
   end
 
   if !screenshots_url.nil?
-      message "[Screenshots](#{screenshots_url})"
+    message "[Screenshots](#{screenshots_url})"
+  else
+    message "Screenshots in progress..."
   end
 else
   warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."

--- a/PRODUCTNAME/Dangerfile
+++ b/PRODUCTNAME/Dangerfile
@@ -54,7 +54,7 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
   xcov = CircleciArtifact::Query.new(url_substring: 'xcov/index.html')
   slather = CircleciArtifact::Query.new(url_substring: 'slather/index.html')
   screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
-  tests = CircleciArtifact::QueryQuery.new(url_substring: 'scan/report.html')
+  tests = CircleciArtifact::Query.new(url_substring: 'scan/report.html')
   queries = [xcov, slather, screenshots, tests]
   results = fetcher.fetch_queries(queries)
 

--- a/PRODUCTNAME/Dangerfile
+++ b/PRODUCTNAME/Dangerfile
@@ -49,14 +49,14 @@ reponame = ENV['CIRCLE_PROJECT_REPONAME']
 build = ENV['CIRCLE_BUILD_NUM']
 
 if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
-  fetcher = CircleciArtifact::Fetcher.new token, username, reponame, build
+  fetcher = CircleciArtifact::Fetcher.new(token: token, username: username, reponame: reponame, build: build)
 
-  xcov = CircleciArtifact::Query.new 'xcov/index.html'
-  slather = CircleciArtifact::Query.new 'slather/index.html'
-  screenshots = CircleciArtifact::Query.new 'screenshots/screenshots.html'
-  tests = CircleciArtifact::Query.new 'scan/report.html'
+  xcov = CircleciArtifact::Query.new(url_substring: 'xcov/index.html')
+  slather = CircleciArtifact::Query.new(url_substring: 'slather/index.html')
+  screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
+  tests = CircleciArtifact::QueryQuery.new(url_substring: 'scan/report.html')
   queries = [xcov, slather, screenshots, tests]
-  results = fetcher.fetch(queries)
+  results = fetcher.fetch_queries(queries)
 
   xcov_url = results.url_for_query(xcov)
   slather_url = results.url_for_query(slather)

--- a/PRODUCTNAME/Gemfile
+++ b/PRODUCTNAME/Gemfile
@@ -7,7 +7,7 @@ gem 'danger-junit'
 # gem 'xcov'
 gem 'xcov', :git => 'https://github.com/Raizlabs/xcov.git', :branch => '1.4.0-rz'
 gem 'slather'
-gem 'circleci_artifact', :git => 'https://github.com/Raizlabs/circleci_artifact.git', :branch => 'master'
+gem 'circleci_artifact'
 
 gem 'fastlane'
 gem 'cocoapods'

--- a/PRODUCTNAME/Gemfile.lock
+++ b/PRODUCTNAME/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/Raizlabs/circleci_artifact.git
-  revision: bbbf364f084774d77ad37feb21254bbce6befc68
-  branch: master
-  specs:
-    circleci_artifact (0.1.0)
-      circleci (~> 2.0)
-
-GIT
   remote: https://github.com/Raizlabs/xcov.git
   revision: 41e7d39f97a1665b3048d9035547b025caf9ff91
   branch: 1.4.0-rz
@@ -38,6 +30,8 @@ GEM
     atomos (0.1.2)
     babosa (1.0.2)
     circleci (2.0.2)
+    circleci_artifact (0.1.0)
+      circleci (~> 2.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
       cork
@@ -109,13 +103,13 @@ GEM
       xcov (>= 1.1.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.2)
     emoji_regex (0.1.1)
     escape (0.0.4)
     excon (0.62.0)
-    faraday (0.14.0)
+    faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -265,7 +259,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.2)
     word_wrap (1.0.0)
     xcodeproj (1.5.7)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -282,7 +276,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  circleci_artifact!
+  circleci_artifact
   cocoapods
   danger
   danger-junit

--- a/PRODUCTNAME/app/fastlane/Fastfile
+++ b/PRODUCTNAME/app/fastlane/Fastfile
@@ -1,5 +1,7 @@
 fastlane_version "2.90.0"
 
+fastlane_require 'circleci_artifact'
+
 default_platform :ios
 
 # Set by build environment
@@ -96,6 +98,35 @@ platform :ios do
       cobertura_xml: "true",
       build_directory: DERIVED_DATA_PATH
     )
+  end
+
+  desc "Posts screenshots to Slack"
+  lane :slackshots do
+    # Getting artifact URLs from CircleCI
+
+    # You must set up the CIRCLE_API_TOKEN manually using these instructions
+    # https://github.com/Raizlabs/ios-template/tree/master/PRODUCTNAME#danger
+    token = ENV['CIRCLE_API_TOKEN']
+    # These are already in the Circle environment
+    # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
+    username = ENV['CIRCLE_PROJECT_USERNAME']
+    reponame = ENV['CIRCLE_PROJECT_REPONAME']
+    build = ENV['CIRCLE_BUILD_NUM']
+
+    if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
+      fetcher = CircleciArtifact::Fetcher.new(token: token, username: username, reponame: reponame, build: build)
+      screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
+      queries = [screenshots]
+      results = fetcher.fetch_queries(queries)
+      screenshots_url = results.url_for_query(screenshots)
+      if !screenshots_url.nil?
+        slack(message: "[Screenshots](#{screenshots_url})", success: true)
+      else
+        slack(message: "Screenshots are missing!", success: false)
+      end
+    else
+      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
+    end
   end
 
   desc "Builds and submits a Develop release to Hockey"

--- a/PRODUCTNAME/app/fastlane/Fastfile
+++ b/PRODUCTNAME/app/fastlane/Fastfile
@@ -53,6 +53,8 @@ platform :ios do
       slather_use_circleci = "true"
     end
 
+    # Add targets here as you create internal frameworks
+    xcov_targets = "debug-PRODUCTNAME.app, Services.framework"
     xcov_scheme = TEST_SCHEME
     xcov_workspace = "PRODUCTNAME.xcworkspace"
 
@@ -60,15 +62,16 @@ platform :ios do
       workspace: xcov_workspace,
       scheme: xcov_scheme,
       output_directory: "#{ENV['RZ_TEST_REPORTS']}/xcov",
-      # Add targets here as you create internal frameworks
-      include_targets: "debug-PRODUCTNAME.app, Services.framework",
+      include_targets: xcov_targets,
       derived_data_path: DERIVED_DATA_PATH
     )
 
     slather_proj = "PRODUCTNAME.xcodeproj"
     slather_workspace = xcov_workspace
     # Only the Services scheme seems to work. It cannot find our app target schemes. 
-    slather_scheme = "Services"
+    slather_scheme = TEST_SCHEME
+    # Add binaries here as you create internal frameworks
+    slather_binaries = ['debug-PRODUCTNAME', 'Services']
     slather_output_directory = "#{ENV['RZ_TEST_REPORTS']}/slather"
 
     # html and cobertura_xml output must be run separately
@@ -76,6 +79,7 @@ platform :ios do
       proj: slather_proj,
       workspace: slather_workspace,
       scheme: slather_scheme,
+      binary_basename: slather_binaries,
       output_directory: slather_output_directory,
       html: "true",
       build_directory: DERIVED_DATA_PATH
@@ -86,6 +90,7 @@ platform :ios do
       proj: slather_proj,
       workspace: slather_workspace,
       scheme: slather_scheme,
+      binary_basename: slather_binaries,
       output_directory: slather_output_directory,
       circleci: slather_use_circleci,
       coveralls: slather_use_coveralls,

--- a/PRODUCTNAME/app/fastlane/Fastfile
+++ b/PRODUCTNAME/app/fastlane/Fastfile
@@ -68,7 +68,6 @@ platform :ios do
 
     slather_proj = "PRODUCTNAME.xcodeproj"
     slather_workspace = xcov_workspace
-    # Only the Services scheme seems to work. It cannot find our app target schemes. 
     slather_scheme = TEST_SCHEME
     # Add binaries here as you create internal frameworks
     slather_binaries = ['debug-PRODUCTNAME', 'Services']

--- a/PRODUCTNAME/app/fastlane/README.md
+++ b/PRODUCTNAME/app/fastlane/README.md
@@ -26,6 +26,11 @@ Runs tests
 fastlane ios coverage
 ```
 Runs Code Coverage
+### ios slackshots
+```
+fastlane ios slackshots
+```
+Posts screenshots to Slack
 ### ios develop
 ```
 fastlane ios develop

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
       # required to set the correct ruby version
       # see https://circleci.com/docs/2.0/testing-ios/#custom-ruby-versions
     shell: /bin/bash --login -eo pipefail
@@ -15,18 +18,17 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
           # Fall back to a previous cache if exact match cannot be found
-          key: 3-gems-
+          key: 4-gems-
       - run:
           name: Restore Gems
           command: |
-           bundle check --gemfile Gemfile || bundle install --gemfile Gemfile
+           bundle check || bundle install
       - save_cache:
-          key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
-          # The path to the gems may change if .ruby-version file is changed or CircleCI image is updated.
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
           paths:
-            - "/Users/distiller/.gem/ruby/2.4.4"
+            - "/Users/distiller/project/app/build/gems"
       # Make sure that the output directory exists
       - run: mkdir $FL_OUTPUT_DIR
       - run:
@@ -83,11 +85,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane develop
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"
@@ -98,11 +114,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane sprint
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"
@@ -113,11 +143,25 @@ jobs:
       FL_OUTPUT_DIR: /Users/distiller/project/output
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
+      BUNDLE_JOBS: 3
+      BUNDLE_RETRY: 3
+      BUNDLE_PATH: /Users/distiller/project/app/build/gems
     shell: /bin/bash --login -eo pipefail
     working_directory: /Users/distiller/project
     steps:
       - checkout
-      - run: bundle install
+      - restore_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 4-gems-
+      - run:
+          name: Restore Gems
+          command: |
+           bundle check || bundle install
+      - save_cache:
+          key: 4-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          paths:
+            - "/Users/distiller/project/app/build/gems"
       - run: cd app && bundle exec fastlane beta
       - store_artifacts:
           path: "${FL_OUTPUT_DIR}/{{ cookiecutter.project_name }}.ipa"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
       - checkout
       - restore_cache:
           key: 3-gems-{{ "{{" }} checksum "Gemfile.lock" {{ "}}" }}
+          # Fall back to a previous cache if exact match cannot be found
+          key: 3-gems-
       - run:
           name: Restore Gems
           command: |
@@ -38,12 +40,6 @@ jobs:
           command: |
             cd app
             bundle exec fastlane coverage
-      - run:
-          name: Screenshots
-          when: always
-          command: |
-            cd app
-            bundle exec fastlane snapshot
       # Store xcov and slather Code Coverage HTML report artifacts
       - store_artifacts:
           path: /Users/distiller/project/app/build/xcov
@@ -52,15 +48,28 @@ jobs:
           path: /Users/distiller/project/app/build/slather
           destination: slather
       - store_artifacts:
-          path: /Users/distiller/project/app/fastlane/screenshots
-          destination: screenshots
-      - store_artifacts:
           path: /Users/distiller/project/app/build/scan
           destination: scan
+      # Update Danger as soon as we have code coverage/tests, while waiting for screenshots to be generated
+      - run:
+          name: Danger
+          when: always
+          command: |
+            bundle exec danger
       - run:
           name: Upload to Codecov
           when: always
           command: bash <(curl -s https://codecov.io/bash) -f app/build/slather/cobertura.xml -X coveragepy -X gcov -X xcode      
+      - run:
+          name: Screenshots
+          when: always
+          command: |
+            cd app
+            bundle exec fastlane snapshot
+      - store_artifacts:
+          path: /Users/distiller/project/app/fastlane/screenshots
+          destination: screenshots
+      # Run Danger again once screenshots are complete
       - run:
           name: Danger
           when: always

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/.circleci/config.yml
@@ -77,6 +77,12 @@ jobs:
           when: always
           command: |
             bundle exec danger
+      - run:
+          name: Post Screenshots to Slack
+          when: always
+          command: |
+            cd app
+            bundle exec fastlane slackshots
             
   integration:
     macos:

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
@@ -64,19 +64,23 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
   tests_url = results.url_for_query(tests)
 
   if !tests_url.nil?
-      message "[Test Results](#{tests_url})"
+    message "[Test Results](#{tests_url})"
+  else
+    message "Tests in progress..."
   end
 
   if !xcov_url.nil?
-      message "[Code Coverage: xcov](#{xcov_url})"
+    message "[Code Coverage: xcov](#{xcov_url})"
   end
 
   if !slather_url.nil?
-      message "[Code Coverage: Slather](#{slather_url})"
+    message "[Code Coverage: Slather](#{slather_url})"
   end
 
   if !screenshots_url.nil?
-      message "[Screenshots](#{screenshots_url})"
+    message "[Screenshots](#{screenshots_url})"
+  else
+    message "Screenshots in progress..."
   end
 else
   warn "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or Danger is not running on CircleCI."

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
@@ -54,7 +54,7 @@ if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
   xcov = CircleciArtifact::Query.new(url_substring: 'xcov/index.html')
   slather = CircleciArtifact::Query.new(url_substring: 'slather/index.html')
   screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
-  tests = CircleciArtifact::QueryQuery.new(url_substring: 'scan/report.html')
+  tests = CircleciArtifact::Query.new(url_substring: 'scan/report.html')
   queries = [xcov, slather, screenshots, tests]
   results = fetcher.fetch_queries(queries)
 

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Dangerfile
@@ -49,14 +49,14 @@ reponame = ENV['CIRCLE_PROJECT_REPONAME']
 build = ENV['CIRCLE_BUILD_NUM']
 
 if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
-  fetcher = CircleciArtifact::Fetcher.new token, username, reponame, build
+  fetcher = CircleciArtifact::Fetcher.new(token: token, username: username, reponame: reponame, build: build)
 
-  xcov = CircleciArtifact::Query.new 'xcov/index.html'
-  slather = CircleciArtifact::Query.new 'slather/index.html'
-  screenshots = CircleciArtifact::Query.new 'screenshots/screenshots.html'
-  tests = CircleciArtifact::Query.new 'scan/report.html'
+  xcov = CircleciArtifact::Query.new(url_substring: 'xcov/index.html')
+  slather = CircleciArtifact::Query.new(url_substring: 'slather/index.html')
+  screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
+  tests = CircleciArtifact::QueryQuery.new(url_substring: 'scan/report.html')
   queries = [xcov, slather, screenshots, tests]
-  results = fetcher.fetch(queries)
+  results = fetcher.fetch_queries(queries)
 
   xcov_url = results.url_for_query(xcov)
   slather_url = results.url_for_query(slather)

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Gemfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Gemfile
@@ -7,7 +7,7 @@ gem 'danger-junit'
 # gem 'xcov'
 gem 'xcov', :git => 'https://github.com/Raizlabs/xcov.git', :branch => '1.4.0-rz'
 gem 'slather'
-gem 'circleci_artifact', :git => 'https://github.com/Raizlabs/circleci_artifact.git', :branch => 'master'
+gem 'circleci_artifact'
 
 gem 'fastlane'
 gem 'cocoapods'

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/Gemfile.lock
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/Raizlabs/circleci_artifact.git
-  revision: bbbf364f084774d77ad37feb21254bbce6befc68
-  branch: master
-  specs:
-    circleci_artifact (0.1.0)
-      circleci (~> 2.0)
-
-GIT
   remote: https://github.com/Raizlabs/xcov.git
   revision: 41e7d39f97a1665b3048d9035547b025caf9ff91
   branch: 1.4.0-rz
@@ -38,6 +30,8 @@ GEM
     atomos (0.1.2)
     babosa (1.0.2)
     circleci (2.0.2)
+    circleci_artifact (0.1.0)
+      circleci (~> 2.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
       cork
@@ -109,13 +103,13 @@ GEM
       xcov (>= 1.1.2)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.2)
     emoji_regex (0.1.1)
     escape (0.0.4)
     excon (0.62.0)
-    faraday (0.14.0)
+    faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -265,7 +259,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.2)
     word_wrap (1.0.0)
     xcodeproj (1.5.7)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -282,7 +276,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  circleci_artifact!
+  circleci_artifact
   cocoapods
   danger
   danger-junit

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
@@ -68,7 +68,6 @@ platform :ios do
 
     slather_proj = "{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj"
     slather_workspace = xcov_workspace
-    # Only the Services scheme seems to work. It cannot find our app target schemes. 
     slather_scheme = TEST_SCHEME
     # Add binaries here as you create internal frameworks
     slather_binaries = ['debug-{{ cookiecutter.project_name | replace(' ', '') }}', 'Services']

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
@@ -53,6 +53,8 @@ platform :ios do
       slather_use_circleci = "true"
     end
 
+    # Add targets here as you create internal frameworks
+    xcov_targets = "debug-{{ cookiecutter.project_name | replace(' ', '') }}.app, Services.framework"
     xcov_scheme = TEST_SCHEME
     xcov_workspace = "{{ cookiecutter.project_name | replace(' ', '') }}.xcworkspace"
 
@@ -60,15 +62,16 @@ platform :ios do
       workspace: xcov_workspace,
       scheme: xcov_scheme,
       output_directory: "#{ENV['RZ_TEST_REPORTS']}/xcov",
-      # Add targets here as you create internal frameworks
-      include_targets: "debug-{{ cookiecutter.project_name | replace(' ', '') }}.app, Services.framework",
+      include_targets: xcov_targets,
       derived_data_path: DERIVED_DATA_PATH
     )
 
     slather_proj = "{{ cookiecutter.project_name | replace(' ', '') }}.xcodeproj"
     slather_workspace = xcov_workspace
     # Only the Services scheme seems to work. It cannot find our app target schemes. 
-    slather_scheme = "Services"
+    slather_scheme = TEST_SCHEME
+    # Add binaries here as you create internal frameworks
+    slather_binaries = ['debug-{{ cookiecutter.project_name | replace(' ', '') }}', 'Services']
     slather_output_directory = "#{ENV['RZ_TEST_REPORTS']}/slather"
 
     # html and cobertura_xml output must be run separately
@@ -76,6 +79,7 @@ platform :ios do
       proj: slather_proj,
       workspace: slather_workspace,
       scheme: slather_scheme,
+      binary_basename: slather_binaries,
       output_directory: slather_output_directory,
       html: "true",
       build_directory: DERIVED_DATA_PATH
@@ -86,6 +90,7 @@ platform :ios do
       proj: slather_proj,
       workspace: slather_workspace,
       scheme: slather_scheme,
+      binary_basename: slather_binaries,
       output_directory: slather_output_directory,
       circleci: slather_use_circleci,
       coveralls: slather_use_coveralls,

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/Fastfile
@@ -1,5 +1,7 @@
 fastlane_version "2.90.0"
 
+fastlane_require 'circleci_artifact'
+
 default_platform :ios
 
 # Set by build environment
@@ -96,6 +98,35 @@ platform :ios do
       cobertura_xml: "true",
       build_directory: DERIVED_DATA_PATH
     )
+  end
+
+  desc "Posts screenshots to Slack"
+  lane :slackshots do
+    # Getting artifact URLs from CircleCI
+
+    # You must set up the CIRCLE_API_TOKEN manually using these instructions
+    # https://github.com/Raizlabs/ios-template/tree/master/{{ cookiecutter.project_name | replace(' ', '') }}#danger
+    token = ENV['CIRCLE_API_TOKEN']
+    # These are already in the Circle environment
+    # https://circleci.com/docs/2.0/env-vars/#build-specific-environment-variables
+    username = ENV['CIRCLE_PROJECT_USERNAME']
+    reponame = ENV['CIRCLE_PROJECT_REPONAME']
+    build = ENV['CIRCLE_BUILD_NUM']
+
+    if !(token.nil? or username.nil? or reponame.nil? or build.nil?)
+      fetcher = CircleciArtifact::Fetcher.new(token: token, username: username, reponame: reponame, build: build)
+      screenshots = CircleciArtifact::Query.new(url_substring: 'screenshots/screenshots.html')
+      queries = [screenshots]
+      results = fetcher.fetch_queries(queries)
+      screenshots_url = results.url_for_query(screenshots)
+      if !screenshots_url.nil?
+        slack(message: "[Screenshots](#{screenshots_url})", success: true)
+      else
+        slack(message: "Screenshots are missing!", success: false)
+      end
+    else
+      slack(message: "Missing CircleCI artifacts. Most likely the [CIRCLE_API_TOKEN](https://github.com/Raizlabs/circleci_artifact#getting-started) is not set, or not running on CircleCI.", success: false)
+    end
   end
 
   desc "Builds and submits a Develop release to Hockey"

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/README.md
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/fastlane/README.md
@@ -26,6 +26,11 @@ Runs tests
 fastlane ios coverage
 ```
 Runs Code Coverage
+### ios slackshots
+```
+fastlane ios slackshots
+```
+Posts screenshots to Slack
 ### ios develop
 ```
 fastlane ios develop


### PR DESCRIPTION
* Add `slackshots` lane for posting screenshots to Slack. It will only work if run on CI, and is intended to be run after the CircleCI build artifacts are uploaded.
* Slather now includes output from both targets (Services and debug-PRODUCTNAME.app)! Unfortunately you need to manually add new targets in two places because of slightly different syntax between xcov and slather.
* Run Danger twice to get faster feedback, once after tests/coverage, and again after screenshots
* Less brittle bundle gem caching, so Ruby updates won't cause issues
