### PR TITLE
Fix SimulatorStatusMagic Compiler Error

### DIFF
--- a/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/StatusBarConfiguration.swift
+++ b/PRODUCTNAME/app/PRODUCTNAME/Application/AppLifecycle/StatusBarConfiguration.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 ORGANIZATION. All rights reserved.
 //
 
-#if targetEnvironment(simulator)
+#if targetEnvironment(simulator) && DEBUG
     import SimulatorStatusMagic
 #endif
 
@@ -17,7 +17,7 @@ struct StatusBarConfiguration: AppLifecycle {
     }
 
     func onDidLaunch(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
-        #if targetEnvironment(simulator)
+        #if targetEnvironment(simulator) && DEBUG
             SDStatusBarManager.sharedInstance().enableOverrides()
         #endif
     }

--- a/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/StatusBarConfiguration.swift
+++ b/{{ cookiecutter.project_name | replace(' ', '') }}/app/{{ cookiecutter.project_name | replace(' ', '') }}/Application/AppLifecycle/StatusBarConfiguration.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 {{ cookiecutter.company_name }}. All rights reserved.
 //
 
-#if targetEnvironment(simulator)
+#if targetEnvironment(simulator) && DEBUG
     import SimulatorStatusMagic
 #endif
 
@@ -17,7 +17,7 @@ struct StatusBarConfiguration: AppLifecycle {
     }
 
     func onDidLaunch(application: UIApplication, launchOptions: [UIApplicationLaunchOptionsKey: Any]?) {
-        #if targetEnvironment(simulator)
+        #if targetEnvironment(simulator) && DEBUG
             SDStatusBarManager.sharedInstance().enableOverrides()
         #endif
     }


### PR DESCRIPTION
The `SimulatorStatusMagic` pod is only installed for debug configurations (see Podfile). This resulted in a compiler error when building non-debug configurations in [client redacted].